### PR TITLE
Fix case-sensitive sorting of filter values in Issues page (Vibe Kanban)

### DIFF
--- a/src/api/routes/issues.ts
+++ b/src/api/routes/issues.ts
@@ -122,8 +122,12 @@ export class IssuesRoutes {
 					totalPages,
 				},
 				availableFilters: {
-					evaluators: Array.from(evaluatorSet).sort(),
-					repositories: Array.from(repositorySet).sort(),
+					evaluators: Array.from(evaluatorSet).sort((a, b) =>
+						a.localeCompare(b, undefined, { sensitivity: "base" }),
+					),
+					repositories: Array.from(repositorySet).sort((a, b) =>
+						a.localeCompare(b, undefined, { sensitivity: "base" }),
+					),
 				},
 			};
 


### PR DESCRIPTION
## Summary

The filter dropdowns (Repository, Evaluator) in the Issues page were sorting values using JavaScript's default `.sort()`, which performs case-sensitive comparison. This caused uppercase entries (e.g., "PostHog/posthog") to appear before lowercase ones (e.g., "bigint/hey"), resulting in an unintuitive ordering for users.

## Changes

- **File**: `src/api/routes/issues.ts`
- Replaced `.sort()` with `.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }))` for both `evaluators` and `repositories` filter arrays
- This applies case-insensitive locale-aware sorting, so entries like "bigint/hey" and "Checkmk/checkmk" are interleaved alphabetically regardless of casing

## Why

The previous case-sensitive sort grouped all uppercase-starting names before lowercase ones, making it harder for users to find repositories and evaluators in the filter dropdowns. Case-insensitive sorting matches user expectations for alphabetical lists.

## Implementation details

- The fix is backend-only — the frontend already renders filter values in the order received from the API
- Uses `localeCompare` with `sensitivity: "base"` which ignores both case and diacritics for sorting
- Hardcoded filters (Severity: High/Medium/Low, Issue Type: Errors/Suggestions) were already in logical order and required no changes

---

This PR was written using [Vibe Kanban](https://vibekanban.com)